### PR TITLE
Added Debian and Ubuntu boxes and Ansible provision.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 *.egg-info
 .pypirc
+.vagrant/
+vagrant_ansible_inventory_*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,12 +3,32 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
-Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "chef/centos-6.5"
-  config.vm.network :forwarded_port, guest: 5000, host: 5000
-  config.vm.provision "shell", path: "vagrant.sh"
+boxes = [
+  {:name => "ubuntu-1204", :box => "opscode-ubuntu-12.04", :url => "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box", :cpu => "50", :ram => "256", :ip => '10.0.1.10'},
+  {:name => "debian-720",  :box => "opscode-debian-7.2.0", :url => "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian_7.2.0_chef-provisionerless.box", :cpu => "50", :ram => "256", :ip => '10.0.1.11'},
+  {:name => "centos-6.5",  :box => "chef/centos-6.5",      :url => "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box", :cpu => "50", :ram => "256", :ip => '10.0.1.12'},
+]
 
-  # config.vm.provider :virtualbox do |vb|
-  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
-  # end
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  boxes.each do |box|
+    config.vm.define box[:name] do |vms|
+      vms.vm.box = box[:box]
+      vms.vm.box_url = box[:url]
+      vms.vm.hostname = "%s" % box[:name]
+
+      vms.vm.provider "virtualbox" do |v|
+        v.customize ["modifyvm", :id, "--cpuexecutioncap", box[:cpu]]
+        v.customize ["modifyvm", :id, "--memory", box[:ram]]
+      end
+
+      vms.vm.network :private_network, ip: box[:ip]
+
+      vms.vm.provision :ansible do |ansible|
+        ansible.playbook = "psdash.yml"
+        ansible.limit = "%s" % box[:name]
+        # ansible.verbose = "vvvv"
+        ansible.host_key_checking = false
+      end
+    end
+  end
 end

--- a/psdash.yml
+++ b/psdash.yml
@@ -1,0 +1,37 @@
+---
+- hosts: all
+
+  tasks:
+    - name: group | Group by OS family
+      group_by: key={{ ansible_os_family }}
+
+- hosts: Debian
+  sudo: yes
+
+  tasks:
+    - name: debian | Install build dependencies
+      apt: pkg={{ item }} state=latest update_cache=yes cache_valid_time=3600
+      with_items:
+        - gcc
+        - make
+        - python-dev
+        - python-setuptools
+
+- hosts: RedHat
+  sudo: yes
+
+  tasks:
+    - name: redhat | Install build dependencies
+      yum: pkg={{ item }} state=latest
+      with_items:
+        - gcc
+        - make
+        - python-devel
+        - python-setuptools
+
+- hosts: all
+  sudo: yes
+
+  tasks:
+    - name: psdash | Install via setup.py
+      command: python setup.py develop chdir=/vagrant


### PR DESCRIPTION
Hi,

I wanted to test psdash in a Debian box, so I ended up adding Debian and Ubuntu boxes (from Chef's Bento project) and Ansible provision. I took the liberty to assume that your "chef/centos-6.5" box also came from that same project and added the respective URL. Hope that's ok! :)

Vagrantfile:
- Added 'boxes' dict with Debian, Ubuntu and CentOS boxes configs;
- Using private addresses on VMs so we no longer need
  port-forwarding, which would complicate maintaining multiple VMs
  for testing;
- Using Ansible for provisioning.

psdash.yml:
- Simple Ansible playbook that installs psdash and its dependencies
  in Red Hat and Debian bases OS.

.gitignore:
- Added vagrant artifacts.
