### PR TITLE
Fix exception thrown when seeing a log that contains non-ascii chars.

### DIFF
--- a/psdash/templates/log.html
+++ b/psdash/templates/log.html
@@ -25,7 +25,7 @@
                     </div>
                 </div>
             </div>
-            <pre id="log-content" data-filename="{{ filename }}" data-mode="tail">{{ content }}</pre>
+            <pre id="log-content" data-filename="{{ filename }}" data-mode="tail">{{ content.decode('utf8') }}</pre>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Having to deal with non-ascii characters in log files is a corner case I suppose - yet I need it :-(
