### PR TITLE
HTML in  a log is not escaped when searching it

### DIFF
--- a/psdash/static/js/psdash.js
+++ b/psdash/static/js/psdash.js
@@ -75,6 +75,7 @@ function init_log() {
             if(resp.position == -1) {
                 $status.text("EOF Reached.");
             } else {
+                resp.content = $('<div/>').text(resp.content).html();
                 var matched_text = '<span class="matching-text">' + params['text'] + '</span>';
                 var found_text = '<span class="found-text">' + params["text"] + '</span>';
                 var content_before = resp.content.slice(0, resp.buffer_pos);


### PR DESCRIPTION
I stumbled upon that while trying out your app:
![capture decran 2014-04-03 a 21 39 59](https://cloud.githubusercontent.com/assets/6030681/2609135/a3b8a4dc-bb72-11e3-86d4-485386d27920.png)
This is definitely an edge case  but worth fixing.
