### PR TITLE
Docu/pip allow externals

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ It would be much appreciated as there's much room for improvements.
 
 Installation using pip:<br>
 `pip install psdash`
+
 Since pip [1.5.1](https://github.com/pypa/pip/issues/1423) you are forced to add `--allow-externals argparse` since the latest argparse is hosted on google code.
 
 Installation from source:<br>


### PR DESCRIPTION
Since pypa/pip#1423 it is no longer allowed to
install packages that are not hosted on PyPI itself by default. It can
be allowed on a per-package basis with the --allow-externals PACKAGE
option.
Since the latest argparse tarball comes from google code, it is
necessary to use --allow-externals for the argparse dependency.
