### PR TITLE
Fix for python 3 support

### DIFF
--- a/psdash/log.py
+++ b/psdash/log.py
@@ -137,7 +137,7 @@ class Logs(object):
             filename = filename.decode("utf-8")
             f = open(filename)
             f.close()
-        except IOError, e:
+        except IOError as e:
             raise LogError("Could not read log file '%s' (%s)" % (filename, e))
 
         logger.debug("Adding log file %s", filename)
@@ -158,7 +158,7 @@ class Logs(object):
             for log_file in glob2.iglob(p):
                 try:
                     self.add_available(log_file)
-                except LogError, e:
+                except LogError as e:
                     logger.warning(e)
 
         logger.info("Added %d log file(s)", len(self.available))

--- a/psdash/web.py
+++ b/psdash/web.py
@@ -363,7 +363,7 @@ def view_log():
         log = logs.get(filename, key=session.get("client_id"))
         log.set_tail_position()
         content = log.read()
-        print log.fp.tell()
+        print(log.fp.tell())
     except KeyError:
         return render_template("error.html", error="Only files passed through args are allowed."), 401
 


### PR DESCRIPTION
There isn't really any reason to not support Python.  I didn't have to change any code whatsoever, just make print not a keyword and fix how exceptions are caught.
