### PR TITLE
CSS: Use a flex layout, with justified content

### DIFF
--- a/psdash/static/css/psdash.css
+++ b/psdash/static/css/psdash.css
@@ -160,8 +160,14 @@ a:hover {
     min-height: 310px;
 }
 
+#dashboard {
+	display: flex;
+	flex-wrap: wrap;
+}
+
 #dashboard div.box {
     display:block;
+    flex-grow: 1;
 }
 
 #dashboard div.box.cpu {


### PR DESCRIPTION
Now the various boxes can appear side by side if there is enough space,
and will fill the width of the parent page in all cases.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>